### PR TITLE
fix(cli): Use system.label instead of system.name to getContractData

### DIFF
--- a/.changeset/silly-kids-enjoy.md
+++ b/.changeset/silly-kids-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Fixed an issue where 'mud verify' will crash after failing to resolve the full contract artifact paths.

--- a/.changeset/silly-kids-enjoy.md
+++ b/.changeset/silly-kids-enjoy.md
@@ -2,4 +2,4 @@
 "@latticexyz/cli": patch
 ---
 
-Fixed an issue where 'mud verify' will crash after failing to resolve the full contract artifact paths.
+Fixed an issue with `mud verify` where system contract artifacts were being resolved incorrectly.

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -74,7 +74,7 @@ const commandModule: CommandModule<Options, Options> = {
     const systems = configSystems.map((system) => {
       const contractData = getContractData(`${system.label}.sol`, system.label, outDir);
       return {
-        name: system.name,
+        name: system.label,
         bytecode: contractData.bytecode,
       };
     });

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -72,7 +72,7 @@ const commandModule: CommandModule<Options, Options> = {
     // TODO: replace with `resolveConfig` and support for linked libs
     const configSystems = await resolveSystems({ rootDir, config });
     const systems = configSystems.map((system) => {
-      const contractData = getContractData(`${system.name}.sol`, system.name, outDir);
+      const contractData = getContractData(`${system.label}.sol`, system.label, outDir);
       return {
         name: system.name,
         bytecode: contractData.bytecode,


### PR DESCRIPTION
Usage of system.name can result in an incorrectly abbreviated contract path. Use system.label to ensure the full path is correctly resolved.